### PR TITLE
Binary log format and log recovery

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,7 +1,7 @@
 package raft
 
 import (
-	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -48,12 +48,12 @@ func (l *Log) recover(r io.Reader) error {
 		switch err := entry.decode(r); err {
 		case io.EOF:
 			return nil // successful completion
-		default:
-			return err // unsuccessful completion
 		case nil:
 			if err = l.appendEntry(entry); err != nil {
 				return err
 			}
+		default:
+			return err // unsuccessful completion
 		}
 	}
 }
@@ -367,6 +367,15 @@ type LogEntry struct {
 }
 
 // encode serializes the log entry to the passed io.Writer.
+//
+// Entries are serialized in a simple binary format:
+//
+//		 ---------------------------------------------
+//		| uint32 | uint64 | uint64 | uint32 | []byte  |
+//		 ---------------------------------------------
+//		| CRC    | TERM   | INDEX  | SIZE   | COMMAND |
+//		 ---------------------------------------------
+//
 func (e *LogEntry) encode(w io.Writer) error {
 	if len(e.Command) <= 0 {
 		return ErrNoCommand
@@ -378,59 +387,51 @@ func (e *LogEntry) encode(w io.Writer) error {
 		return ErrBadTerm
 	}
 
-	buf := &bytes.Buffer{}
-	if _, err := fmt.Fprintf(buf, "%016x %016x %s\n", e.Index, e.Term, e.Command); err != nil {
-		return err
-	}
+	commandSize := len(e.Command)
+	buf := make([]byte, 24+commandSize)
 
-	checksum := crc32.ChecksumIEEE(buf.Bytes())
-	_, err := fmt.Fprintf(w, "%08x %s", checksum, buf.String())
+	binary.LittleEndian.PutUint64(buf[4:12], e.Term)
+	binary.LittleEndian.PutUint64(buf[12:20], e.Index)
+	binary.LittleEndian.PutUint32(buf[20:24], uint32(commandSize))
+
+	copy(buf[24:], e.Command)
+
+	binary.LittleEndian.PutUint32(
+		buf[0:4],
+		crc32.ChecksumIEEE(buf[4:]),
+	)
+
+	_, err := w.Write(buf)
 	return err
 }
 
 // decode deserializes one log entry from the passed io.Reader.
 func (e *LogEntry) decode(r io.Reader) error {
-	var readChecksum uint32
-	if _, err := fmt.Fscanf(r, "%08x ", &readChecksum); err != nil {
+	header := make([]byte, 24)
+
+	if _, err := r.Read(header); err != nil {
 		return err
 	}
 
-	if _, err := fmt.Fscanf(r, "%016x ", &e.Index); err != nil {
+	command := make([]byte, binary.LittleEndian.Uint32(header[20:24]))
+
+	if _, err := r.Read(command); err != nil {
 		return err
 	}
 
-	if _, err := fmt.Fscanf(r, "%016x ", &e.Term); err != nil {
-		return err
-	}
+	crc := binary.LittleEndian.Uint32(header[:4])
 
-	if err := consumeUntil(r, '\n', &e.Command); err != nil {
-		return err
-	}
+	check := crc32.NewIEEE()
+	check.Write(header[4:])
+	check.Write(command)
 
-	b := fmt.Sprintf("%016x %016x %s\n", e.Index, e.Term, e.Command)
-	computedChecksum := crc32.ChecksumIEEE([]byte(b))
-	if computedChecksum != readChecksum {
+	if crc != check.Sum32() {
 		return ErrInvalidChecksum
 	}
 
-	return nil
-}
+	e.Term = binary.LittleEndian.Uint64(header[4:12])
+	e.Index = binary.LittleEndian.Uint64(header[12:20])
+	e.Command = command
 
-// consumeUntil does a series of 1-byte Reads from the passed io.Reader
-// until it reaches delim, or EOF. This is pretty inefficient.
-func consumeUntil(r io.Reader, delim byte, dst *[]byte) error {
-	p := make([]byte, 1)
-	for {
-		n, err := r.Read(p)
-		if err != nil {
-			return err
-		}
-		if n != 1 {
-			return io.ErrUnexpectedEOF
-		}
-		if p[0] == delim {
-			return nil
-		}
-		*dst = append(*dst, p[0])
-	}
+	return nil
 }

--- a/log.go
+++ b/log.go
@@ -49,9 +49,11 @@ func (l *Log) recover(r io.Reader) error {
 		case io.EOF:
 			return nil // successful completion
 		case nil:
-			if err = l.appendEntry(entry); err != nil {
+			if err := l.appendEntry(entry); err != nil {
 				return err
 			}
+			l.commitPos++
+			l.apply(entry.Index, entry.Command)
 		default:
 			return err // unsuccessful completion
 		}

--- a/log_test.go
+++ b/log_test.go
@@ -364,6 +364,20 @@ func TestCleanLogRecovery(t *testing.T) {
 		t.Errorf("log doesn't contain index=3 term=2")
 	}
 
+	if expected, got := uint64(3), log.getCommitIndex(); expected != got {
+		t.Errorf("expected commit index = %d, got %d", expected, got)
+	}
+
+	if expected, got := uint64(2), log.lastTerm(); expected != got {
+		t.Errorf("expected term = %d, got %d", expected, got)
+	}
+
+	log.commitTo(3) // should be a no-op
+
+	if buf.Len() > 0 {
+		t.Errorf("commit to recovered index wrote to buffer")
+	}
+
 	if err := log.appendEntry(LogEntry{
 		Index:   4,
 		Term:    3,

--- a/log_test.go
+++ b/log_test.go
@@ -153,12 +153,23 @@ func TestLogAppend(t *testing.T) {
 	}
 
 	// Check our flush buffer
-	lines := []string{
-		`02869b0c 0000000000000001 0000000000000001 {}`,
-		`3bfe364c 0000000000000002 0000000000000001 {}`,
-	}
-	if expected, got := strings.Join(lines, "\n")+"\n", buf.String(); expected != got {
-		t.Errorf("after commit, expected:\n%s\ngot:\n%s\n", expected, got)
+	for i, expected := range log.entries[:2] {
+		var got LogEntry
+		if err := got.decode(buf); err != nil {
+			t.Fatalf("after commit, got: %s", err)
+		}
+
+		if expected.Term != got.Term {
+			t.Errorf("%d. decode expected term=%d, got %d", i, expected.Term, got.Term)
+		}
+
+		if expected.Index != got.Index {
+			t.Errorf("%d. decode expected index=%d, got %d", i, expected.Index, got.Index)
+		}
+
+		if !bytes.Equal(expected.Command, got.Command) {
+			t.Errorf("%d. decode expected command=%q, got %q", i, expected.Command, got.Command)
+		}
 	}
 
 	// Make some invalid commits
@@ -174,13 +185,23 @@ func TestLogAppend(t *testing.T) {
 		t.Errorf("commitTo: %s", err)
 	}
 
-	// Check our flush buffer again
-	lines = append(
-		lines,
-		`6b76285c 0000000000000003 0000000000000002 {}`,
-	)
-	if expected, got := strings.Join(lines, "\n")+"\n", buf.String(); expected != got {
-		t.Errorf("after commit, expected:\n%s\ngot:\n%s\n", expected, got)
+	// Check our buffer again
+	expected := log.entries[2]
+	var got LogEntry
+	if err := got.decode(buf); err != nil {
+		t.Fatalf("after commit, got: %s", err)
+	}
+
+	if expected.Term != got.Term {
+		t.Errorf("%d. decode expected term=%d, got %d", 3, expected.Term, got.Term)
+	}
+
+	if expected.Index != got.Index {
+		t.Errorf("%d. decode expected index=%d, got %d", 3, expected.Index, got.Index)
+	}
+
+	if !bytes.Equal(expected.Command, got.Command) {
+		t.Errorf("%d. decode expected command=%q, got %q", 3, expected.Command, got.Command)
 	}
 }
 
@@ -317,16 +338,19 @@ func TestLogCommitTwice(t *testing.T) {
 }
 
 func TestCleanLogRecovery(t *testing.T) {
-	lines := []string{
-		`02869b0c 0000000000000001 0000000000000001 {}`,
-		`3bfe364c 0000000000000002 0000000000000001 {}`,
-		`6b76285c 0000000000000003 0000000000000002 {}`,
+	entries := []LogEntry{
+		{1, 1, []byte("{}"), nil},
+		{2, 1, []byte("{}"), nil},
+		{3, 2, []byte("{}"), nil},
 	}
 
-	buf := bytes.NewBufferString(strings.Join(lines, "\n") + "\n")
+	buf := new(bytes.Buffer)
+	for _, entry := range entries {
+		entry.encode(buf)
+	}
 	log := NewLog(buf, noop)
 
-	if expected, got := len(lines), len(log.entries); expected != got {
+	if expected, got := len(entries), len(log.entries); expected != got {
 		t.Fatalf("expected %d, got %d", expected, got)
 	}
 
@@ -356,16 +380,18 @@ func TestCleanLogRecovery(t *testing.T) {
 }
 
 func TestCorruptedLogRecovery(t *testing.T) {
-	lines := []string{
-		`02869b0c 0000000000000001 0000000000000001 {}`,
-		`3000000c 0000000000000002 0000000000000001 {}`, // bad line
-		`6b76285c 0000000000000003 0000000000000002 {}`,
+	entries := []LogEntry{
+		{1, 1, []byte("{}"), nil},
 	}
 
-	buf := bytes.NewBufferString(strings.Join(lines, "\n") + "\n")
+	buf := new(bytes.Buffer)
+	for _, entry := range entries {
+		entry.encode(buf)
+	}
+	buf.Write([]byte("garbage"))
 	log := NewLog(buf, noop)
 
-	if expected, got := 1, len(log.entries); expected != got {
+	if expected, got := len(entries), len(log.entries); expected != got {
 		t.Fatalf("expected %d, got %d", expected, got)
 	}
 

--- a/server.go
+++ b/server.go
@@ -148,13 +148,18 @@ func NewServer(id uint64, store io.ReadWriter, apply func(uint64, []byte) []byte
 		panic("server id must be > 0")
 	}
 
+	log := NewLog(store, apply)
+	// 5.2 Leader election: the latest term this server has seen is persisted,
+	// and is initialized to 0 on first boot.
+	latestTerm := log.lastTerm()
+
 	s := &Server{
 		id:            id,
 		state:         &serverState{value: Follower}, // "when servers start up they begin as followers"
 		running:       &serverRunning{value: false},
 		leader:        unknownLeader, // unknown at startup
-		term:          1,             // TODO is this correct?
-		log:           NewLog(store, apply),
+		log:           log,
+		term:          latestTerm,
 		configuration: nil,
 
 		appendEntriesChan: make(chan appendEntriesTuple),


### PR DESCRIPTION
This covers a few changes:
1. Switches to a simple binary log format
2. Fixes a bug in log replay, where recovered values would be re-committed to the log
3. Fixes a bug in server startup, where term counters would be reset.
