### PR TITLE
example: added sleep before s.Start()

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -38,7 +38,9 @@ func ExampleNewServer_hTTP() {
 	// Expose the server using a HTTP transport
 	raft.HTTPTransport(http.DefaultServeMux, s)
 	go http.ListenAndServe(":8080", nil)
-
+	
+	time.Sleep(time.Second)
+	
 	// Set the initial server configuration
 	s.SetConfiguration(
 		mustNewHTTPPeer(mustParseURL("http://127.0.0.1:8080")), // this server


### PR DESCRIPTION
9 out of 10 times s.Start fails if you don't it doesn't sleep before s.Start()

panic: Get http://127.0.0.1:8080/raft/id: dial tcp 127.0.0.1:8080: getsockopt: connection refused
